### PR TITLE
 Fix: allow dash in usernames in PR title linting @geminixiang

### DIFF
--- a/src/pr_lint/linter.py
+++ b/src/pr_lint/linter.py
@@ -16,7 +16,7 @@ def lint(pr: PullRequest) -> None:
         pr: The pull request to lint
     """
 
-    pr_owners = re.findall(r"(@[\w]+)$", pr.title.strip())
+    pr_owners = re.findall(r"(@[\w-]+)$", pr.title.strip())
     assert pr_owners, "PR title should end with a GitHub username"
     # FIXME: for some reason the has_in_collaborators method is not working
     # pr_owner = pr_owners[0][1:]


### PR DESCRIPTION
1. 修復 PR title 內，username 含有 "-" 會查找不到的問題 https://github.com/livingbio/gstudio/pull/15623#issuecomment-2175058726