### PR TITLE
 chore: switch from pre-commit to prek @anthropic-bot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ pr-lint = "pr_lint.main:app"
 dev = [
     "pytest==8.3.4",
     "syrupy==4.8.0",
-    "pre-commit==4.6.0",
+    "prek>=0.1",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- Replace `pre-commit` dependency with `prek>=0.1` in pyproject.toml and/or Makefile
- `prek` is a drop-in replacement for `pre-commit`

## Test plan
- [ ] `make install` or `uv sync` works correctly
- [ ] `prek run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)